### PR TITLE
Fix Z3D convnext retrieval

### DIFF
--- a/model_registry.json
+++ b/model_registry.json
@@ -33,8 +33,11 @@
     "backend": "pytorch"
   },
   "z3d_convnext": {
-    "repo": "Thouph/Z3D-Convnext",
-    "subfolder": "",
+    "repo": "",
+    "urls": [
+      "https://pixeldrain.com/api/file/iNMyyi2w"
+    ],
+    "subfolder": "Z3D-E621-Convnext",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 9525,


### PR DESCRIPTION
## Summary
- fix registry entry for Z3D ConvNext
- support downloading models from direct URLs with post-processing

## Testing
- `python -m json.tool model_registry.json`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686dc002334883218258e4b22599bd8a