### PR TITLE
Persist tokens and model settings

### DIFF
--- a/openrouter_tab.py
+++ b/openrouter_tab.py
@@ -31,26 +31,21 @@ Your task is to describe every aspect, object, and interaction within this image
     \"\u2022 use underscores_not_spaces \"
     \"\u2022 (((return ONLY a comma-separated list of tags, nothing else.)))""".strip()
 
-CONFIG_PATH = Path(__file__).with_name("session_config.json")
+from user_config import load_config, update_config
 
 
-def load_config() -> dict:
-    if CONFIG_PATH.exists():
-        try:
-            return json.loads(CONFIG_PATH.read_text())
-        except Exception:
-            pass
-    return {}
+def _load_section() -> dict:
+    return load_config().get("openrouter", {})
 
 
 def save_config(api_key: str, model: str, mode: str, prompt_extra: str):
-    data = {
-        "api_key": api_key.strip(),
-        "model": model,
-        "mode": mode,
-        "prompt_extra": prompt_extra,
-    }
-    CONFIG_PATH.write_text(json.dumps(data, indent=2))
+    update_config(
+        "openrouter",
+        api_key=api_key.strip(),
+        model=model,
+        mode=mode,
+        prompt_extra=prompt_extra,
+    )
 
 
 def read_file_utf8(path: Path) -> str:
@@ -174,7 +169,7 @@ def process_batch(api_key: str, mode: str, prompt_extra: str, folder: str, model
 
 
 def add_openrouter_tab():
-    cfg = load_config()
+    cfg = _load_section()
     with gr.Tab("OpenRouter Tagger"):
         gr.Markdown("## Character-LoRA Tagging / Tag-Refinement Tool")
         with gr.Row():

--- a/user_config.py
+++ b/user_config.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).with_name("user_config.json")
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        try:
+            return json.loads(CONFIG_PATH.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    CONFIG_PATH.write_text(json.dumps(cfg, indent=2))
+
+
+def update_config(section: str, **kwargs) -> None:
+    cfg = load_config()
+    sec = cfg.get(section, {})
+    sec.update({k: v for k, v in kwargs.items() if v is not None})
+    cfg[section] = sec
+    save_config(cfg)


### PR DESCRIPTION
## Summary
- centralize user configuration with `user_config.py`
- persist OpenRouter tokens and settings via the new config helpers
- save HuggingFace tokens and model options in tag cleaner
- remember model selections and captioner settings in the main UI

## Testing
- `python -m py_compile user_config.py openrouter_tab.py tag_cleaner_app.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc691d7488321a2dc88dea3efce49