### PR TITLE
Lazy load tag files per model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore downloaded models and tag files
+models/
+tagger_tags.json
+*tags.json
+tags.csv
+__pycache__/


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude downloaded tag files and models
- lazily load tag files for each model only when needed
- update classification and Grad-CAM utilities to use model-specific tags
- handle missing tag selection when adjusting Grad-CAM sliders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686f34369b748321b29b1fcd5de1a494