### PR TITLE
Fix tags file path in registry

### DIFF
--- a/model_registry.json
+++ b/model_registry.json
@@ -5,7 +5,7 @@
     "filename": "JTP_PILOT2-e3-vit_so400m_patch14_siglip_384.safetensors",
     "timm_id": "vit_so400m_patch14_siglip_384.webli",
     "num_classes": 9083,
-    "tags_file": "tagger_tags.json",
+    "tags_file": "tags.json",
     "head_type": "gated",
     "supports_cam": true,
     "backend": "pytorch"
@@ -16,7 +16,7 @@
     "filename": "JTP_PILOT-e4-vit_so400m_patch14_siglip_384.safetensors",
     "timm_id": "vit_so400m_patch14_siglip_384.webli",
     "num_classes": 9083,
-    "tags_file": "tagger_tags.json",
+    "tags_file": "tags.json",
     "head_type": "linear",
     "supports_cam": true,
     "backend": "pytorch"
@@ -27,7 +27,7 @@
     "filename": "JTP_PILOT2-2-e3-vit_so400m_patch14_siglip_384.safetensors",
     "timm_id": "vit_so400m_patch14_siglip_384.webli",
     "num_classes": 9083,
-    "tags_file": "tagger_tags.json",
+    "tags_file": "tags.json",
     "head_type": "gated",
     "supports_cam": true,
     "backend": "pytorch"


### PR DESCRIPTION
## Summary
- correct `tags_file` paths for `pilot` models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687080ef8acc8321b9d1bfeaf3041911