### PR TITLE
Fix pilot2-2 model registry path

### DIFF
--- a/model_registry.json
+++ b/model_registry.json
@@ -23,8 +23,8 @@
   },
   "pilot2-2": {
     "repo": "RedRocket/JointTaggerProject",
-    "subfolder": "JTP_PILOT2-2",
-    "filename": "JTP_PILOT2-2-e3-vit_so400m_patch14_siglip_384.safetensors",
+    "subfolder": "JTP_PILOT2_2",
+    "filename": "JTP_PILOT2_2-e3-vit_so400m_patch14_siglip_384.safetensors",
     "timm_id": "vit_so400m_patch14_siglip_384.webli",
     "num_classes": 9083,
     "tags_file": "tags.json",


### PR DESCRIPTION
## Summary
- fix HuggingFace path for `pilot2-2` model
- support ONNX models that expect NHWC inputs and resize automatically

## Testing
- `python -m py_compile app.py`
- `pip install huggingface_hub`
- `pip install onnxruntime`


------
https://chatgpt.com/codex/tasks/task_e_6871a86b44308321a0e9b0f96d53ecd8