### PR TITLE
Disable image normalization for Z3D ConvNeXt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ All features here will be integrated into the data curation tool.
 Credits for current model development/options:
 - https://huggingface.co/RedRocket/JointTaggerProject
 - https://huggingface.co/fancyfeast
+
+### Model-specific notes
+
+- **z3d_convnext**: this ONNX model expects raw pixel values in `[0, 1]` range.
+  Unlike the other classifiers, mean normalization is not applied during
+  preprocessing.


### PR DESCRIPTION
## Summary
- add a normalization-free transform for models that don't expect zero-centered inputs
- tag each loaded model with its registry key
- pick transform dynamically so `z3d_convnext` skips mean normalization
- document preprocessing difference in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6871af6165348321b7cac8ac2f299e67