### PR TITLE
Fix huggingface model download directories

### DIFF
--- a/model_registry.json
+++ b/model_registry.json
@@ -37,7 +37,7 @@
   },
   "eva02_clip_7704": {
     "repo": "Thouph/eva02-clip-vit-large-7704",
-    "subfolder": "",
+    "subfolder": "eva02_clip_7704",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 7704,
@@ -48,7 +48,7 @@
   },
   "eva02_vit_8046": {
     "repo": "Thouph/eva02-vit-large-448-8046",
-    "subfolder": "",
+    "subfolder": "eva02_vit_8046",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 8046,
@@ -59,7 +59,7 @@
   },
   "efficientnetv2_m_8035": {
     "repo": "Thouph/experimental_efficientnetv2_m_8035",
-    "subfolder": "",
+    "subfolder": "efficientnetv2_m_8035",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 8035,


### PR DESCRIPTION
## Summary
- assign individual download directories for Eva02 and EfficientNetV2 models

## Testing
- `python -m json.tool model_registry.json`

------
https://chatgpt.com/codex/tasks/task_e_68729d8296c08321a38c1dbab4a5d806