### PR TITLE
Fix model download path

### DIFF
--- a/model_registry.json
+++ b/model_registry.json
@@ -59,7 +59,7 @@
   },
   "efficientnetv2_m_8035": {
     "repo": "Thouph/experimental_efficientnetv2_m_8035",
-    "subfolder": "efficientnetv2_m_8035",
+    "subfolder": "",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 8035,


### PR DESCRIPTION
## Summary
- adjust subfolder for efficientnet model
- handle missing subfolder gracefully when downloading models and tag files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6872a0d86a70832183ce027963a0199c