### PR TITLE
Fix model download path

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,20 @@ import torch.nn.functional as F
 import timm, safetensors.torch, gradio as gr
 import onnxruntime as ort
 from huggingface_hub import hf_hub_download
+try:
+    # Available in newer versions
+    from huggingface_hub import EntryNotFoundError
+except Exception:  # pragma: no cover - maintain compatibility
+    try:
+        # Older versions expose HTTP errors under this name
+        from huggingface_hub import HfHubHTTPError as EntryNotFoundError
+    except Exception:
+        try:
+            from huggingface_hub.utils import HfHubHTTPError as EntryNotFoundError
+        except Exception:
+            class EntryNotFoundError(Exception):
+                """Fallback when huggingface_hub doesn't expose specific errors."""
+                pass
 import requests
 from tqdm import tqdm
 from transformers import (
@@ -259,12 +273,21 @@ def load_model(key: str, device: torch.device, progress: gr.Progress | None = No
         tracker(0, desc=f"Downloading {key} …", total=1, unit="file")
 
         if spec.get("repo"):
-            hf_hub_download(
-                repo_id=spec["repo"],
-                subfolder=spec["subfolder"],
-                filename=spec["filename"],
-                local_dir=ckpt_root,
-            )
+            subf = spec.get("subfolder") or None
+            try:
+                hf_hub_download(
+                    repo_id=spec["repo"],
+                    subfolder=subf,
+                    filename=spec["filename"],
+                    local_dir=ckpt_root,
+                )
+            except EntryNotFoundError:
+                # Retry download from repository root if subfolder path is wrong
+                hf_hub_download(
+                    repo_id=spec["repo"],
+                    filename=spec["filename"],
+                    local_dir=ckpt_root,
+                )
         elif spec.get("urls"):
             for url in spec["urls"]:
                 fname = url.split("/")[-1]
@@ -426,12 +449,20 @@ def load_tags(model_key: str) -> tuple[list[str], dict[str, int]]:
 
     if not path.exists():
         if spec.get("repo"):
-            hf_hub_download(
-                repo_id=spec["repo"],
-                subfolder=spec["subfolder"],
-                filename=fname,
-                local_dir=MODELS_DIR,
-            )
+            subf = spec.get("subfolder") or None
+            try:
+                hf_hub_download(
+                    repo_id=spec["repo"],
+                    subfolder=subf,
+                    filename=fname,
+                    local_dir=MODELS_DIR,
+                )
+            except EntryNotFoundError:
+                hf_hub_download(
+                    repo_id=spec["repo"],
+                    filename=fname,
+                    local_dir=MODELS_DIR,
+                )
         elif spec.get("urls"):
             for url in spec["urls"]:
                 dest = MODELS_DIR / url.split("/")[-1]

--- a/model_registry.json
+++ b/model_registry.json
@@ -59,7 +59,7 @@
   },
   "efficientnetv2_m_8035": {
     "repo": "Thouph/experimental_efficientnetv2_m_8035",
-    "subfolder": "efficientnetv2_m_8035",
+    "subfolder": "",
     "filename": "model.onnx",
     "timm_id": "",
     "num_classes": 8035,


### PR DESCRIPTION
## Summary
- adjust subfolder for efficientnet model
- handle missing subfolder gracefully when downloading models and tag files
- ensure compatibility with older huggingface_hub versions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6872a0d86a70832183ce027963a0199c