### PR TITLE
Fix Grad-CAM overlay

### DIFF
--- a/app.py
+++ b/app.py
@@ -927,9 +927,10 @@ def grad_cam(img: Image.Image, tag: str, m: torch.nn.Module,
 
     h1.remove(); h2.remove()
 
-    overlay = create_cam_visualization_pil(img, cam, alpha=alpha, vis_threshold=thr)
+    # Create RGBA heat‑map overlay then composite it over the source image
+    overlay = _cam_to_overlay(cam, img, alpha=alpha, thr=thr)
     comp    = Image.alpha_composite(img.convert("RGBA"), overlay)
-    return comp, overlay             # ← second result is the pure heat-map RGBA
+    return comp, overlay             # second result is the pure heat-map RGBA
 # ╰─────────────────────────────────────╯
 
 


### PR DESCRIPTION
## Summary
- compute Grad-CAM heat map using `_cam_to_overlay`
- composite RGBA overlay over the source image

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6873dc91a3fc83219fda01a770bb0839