### PR TITLE
Fix Grad-CAM normalization

### DIFF
--- a/app.py
+++ b/app.py
@@ -924,12 +924,15 @@ def grad_cam(img: Image.Image, tag: str, m: torch.nn.Module,
         P = cam_1d.numel()
         h, w_ = _best_grid(P)                       # 27×27 for ViT‑384, 24×48 for SigLIP, etc.
         cam = cam_1d.reshape(h, w_).cpu().numpy()
+        cam -= cam.min()
+        cam /= cam.max() + 1e-8
 
     h1.remove(); h2.remove()
 
-    overlay = create_cam_visualization_pil(img, cam, alpha=alpha, vis_threshold=thr)
+    # Create RGBA heat‑map overlay then composite it over the source image
+    overlay = _cam_to_overlay(cam, img, alpha=alpha, thr=thr)
     comp    = Image.alpha_composite(img.convert("RGBA"), overlay)
-    return comp, overlay             # ← second result is the pure heat-map RGBA
+    return comp, overlay             # second result is the pure heat-map RGBA
 # ╰─────────────────────────────────────╯
 
 


### PR DESCRIPTION
## Summary
- normalize Grad-CAM array before creating overlay

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6873dc91a3fc83219fda01a770bb0839