### PR TITLE
Fix additional caption model configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ When you select a different caption model in the UI, the previous model is
 unloaded automatically. If you still hit CUDA out-of-memory errors after
 switching models, the new model likely requires more VRAM than is available on a
 single GPU—enable multiple GPUs in the interface or choose a smaller model.
+If Kosmos‑2 fails to load with a `KeyError` mentioning `kosmos_2_vision_model`,
+update the `transformers` library or use the latest code which patches the
+missing configuration automatically.
+If Qwen‑VL reports a missing `tiktoken` module, install the optional
+`tiktoken` package.

--- a/app.py
+++ b/app.py
@@ -50,6 +50,24 @@ from transformers import (
     TextIteratorStreamer,
     AutoProcessor,
 )
+from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+from transformers.models.kosmos2 import Kosmos2VisionConfig, Kosmos2TextConfig
+from transformers.models.blip_2 import Blip2VisionConfig, Blip2QFormerConfig
+from transformers.models.instructblip import (
+    InstructBlipVisionConfig,
+    InstructBlipQFormerConfig,
+)
+
+# Register missing vision/q-former configs for older Transformers versions
+try:
+    CONFIG_MAPPING.register("kosmos_2_vision_model", Kosmos2VisionConfig, exist_ok=True)
+    CONFIG_MAPPING.register("kosmos_2_text_model", Kosmos2TextConfig, exist_ok=True)
+    CONFIG_MAPPING.register("blip_2_vision_model", Blip2VisionConfig, exist_ok=True)
+    CONFIG_MAPPING.register("blip_2_qformer_model", Blip2QFormerConfig, exist_ok=True)
+    CONFIG_MAPPING.register("instructblip_vision_model", InstructBlipVisionConfig, exist_ok=True)
+    CONFIG_MAPPING.register("instructblip_qformer_model", InstructBlipQFormerConfig, exist_ok=True)
+except Exception:
+    pass
 import json, math
 from user_config import load_config, update_config
 from openrouter_tab import add_openrouter_tab
@@ -355,14 +373,20 @@ def caption_once(
         image_token = "<image>"
     convo = [
         {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": f"{image_token}\n{prompt.strip()}"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": prompt.strip()},
+            ],
+        },
     ]
     convo_str = processor.apply_chat_template(
         convo,
         tokenize=False,
         add_generation_prompt=True,
     )
-    inputs = processor(text=[convo_str], images=[img], return_tensors="pt")
+    inputs = processor(images=img, text=convo_str, return_tensors="pt")
     inputs = {k: v.to(device) for k, v in inputs.items()}
     inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
     out = model.generate(
@@ -1349,19 +1373,20 @@ with demo:
     with gr.Tab("Single Image"):
         with gr.Row():
             with gr.Column():
-                with gr.Tab("Original"):
-                    img_orig = gr.Image(         # new — shows uploaded image untouched
-                        sources=["upload", "clipboard"],
-                        type="pil",
-                        label="Source",
-                        elem_id="image_container",
-                    )
-                with gr.Tab("Grad-CAM"):
-                    img_cam = gr.Image(          # new — shows heat-map overlay
-                        type="pil",
-                        label="CAM",
-                        elem_id="image_container",
-                    )
+                with gr.Accordion("Input Image", open=True):
+                    with gr.Tab("Original"):
+                        img_orig = gr.Image(         # new — shows uploaded image untouched
+                            sources=["upload", "clipboard"],
+                            type="pil",
+                            label="Source",
+                            elem_id="image_container",
+                        )
+                    with gr.Tab("Grad-CAM"):
+                        img_cam = gr.Image(          # new — shows heat-map overlay
+                            type="pil",
+                            label="CAM",
+                            elem_id="image_container",
+                        )
                 cam_thr  = gr.Slider(0, 1, 0.4, 0.01, label="CAM threshold",
                                      elem_classes="inferno-slider")#.4
                 cam_alpha= gr.Slider(0, 1, 0.6, 0.01, label="CAM alpha")#.6
@@ -1404,7 +1429,8 @@ with demo:
         )
 
         with gr.Tab("Single"):
-            cap_image = gr.Image(type="pil", label="Input Image")
+            with gr.Accordion("Input Image", open=True):
+                cap_image = gr.Image(type="pil", label="Input Image")
             cap_type = gr.Dropdown(
                 choices=list(CAPTION_TYPE_MAP.keys()),
                 value=CFG_CAPTION.get("type", "Descriptive"),

--- a/environment.yml
+++ b/environment.yml
@@ -25,9 +25,9 @@ dependencies:
       - safetensors                       #==0.4.3
       - gradio
       - huggingface_hub
+      - tiktoken                      # Qwen tokenizer requirement
       - sentencepiece                    # some models need it
       - jinja2                           # chat-template rendering
-      - gradio
       - rich                             # nicer CLI logs (optional)
       - python-dotenv>=1.0        # convenience only – optional
       - onnxruntime

--- a/openrouter_tab.py
+++ b/openrouter_tab.py
@@ -182,7 +182,8 @@ def add_openrouter_tab():
         prompt_in = gr.Textbox(label="Extra instructions for the LLM (optional)", lines=3, value=cfg.get("prompt_extra", ""))
         gr.Markdown("### Single Image")
         with gr.Row():
-            image_in = gr.Image(label="Image", type="filepath")
+            with gr.Accordion("Input Image", open=True):
+                image_in = gr.Image(label="Image", type="filepath")
             tag_file_in = gr.File(label="Tag File (.txt)", file_types=["text"], interactive=True)
         run_single_btn = gr.Button("Run (Single Image)", variant="primary")
         single_out = gr.Textbox(label="New Tag String", show_copy_button=True)


### PR DESCRIPTION
## Summary
- register BLIP-2 and InstructBLIP config types when loading caption models
- add optional tiktoken dependency for Qwen-VL
- document Qwen-VL tiktoken issue in README
- merge latest main to include image-input accordions

## Testing
- `python -m py_compile app.py openrouter_tab.py`


------
https://chatgpt.com/codex/tasks/task_e_6874782d84688321af413ac4469dcf01