### PR TITLE
Fix additional caption model configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ When you select a different caption model in the UI, the previous model is
 unloaded automatically. If you still hit CUDA out-of-memory errors after
 switching models, the new model likely requires more VRAM than is available on a
 single GPU—enable multiple GPUs in the interface or choose a smaller model.
+If Kosmos‑2 fails to load with a `KeyError` mentioning `kosmos_2_vision_model`,
+update the `transformers` library or use the latest code which patches the
+missing configuration automatically.
+If Qwen‑VL reports a missing `tiktoken` module, install the optional
+`tiktoken` package.

--- a/environment.yml
+++ b/environment.yml
@@ -25,9 +25,9 @@ dependencies:
       - safetensors                       #==0.4.3
       - gradio
       - huggingface_hub
+      - tiktoken                      # Qwen tokenizer requirement
       - sentencepiece                    # some models need it
       - jinja2                           # chat-template rendering
-      - gradio
       - rich                             # nicer CLI logs (optional)
       - python-dotenv>=1.0        # convenience only – optional
       - onnxruntime

--- a/openrouter_tab.py
+++ b/openrouter_tab.py
@@ -182,7 +182,8 @@ def add_openrouter_tab():
         prompt_in = gr.Textbox(label="Extra instructions for the LLM (optional)", lines=3, value=cfg.get("prompt_extra", ""))
         gr.Markdown("### Single Image")
         with gr.Row():
-            image_in = gr.Image(label="Image", type="filepath")
+            with gr.Accordion("Input Image", open=True):
+                image_in = gr.Image(label="Image", type="filepath")
             tag_file_in = gr.File(label="Tag File (.txt)", file_types=["text"], interactive=True)
         run_single_btn = gr.Button("Run (Single Image)", variant="primary")
         single_out = gr.Textbox(label="New Tag String", show_copy_button=True)


### PR DESCRIPTION
## Summary
- register BLIP-2 and InstructBLIP config types when loading caption models
- add optional tiktoken dependency for Qwen-VL
- document Qwen-VL tiktoken issue in README
- merge latest main to include image-input accordions
- skip config registration when Transformers lacks Kosmos-2 imports

## Testing
- `python -m py_compile app.py openrouter_tab.py`


------
https://chatgpt.com/codex/tasks/task_e_6874782d84688321af413ac4469dcf01